### PR TITLE
Add back use_artist_mbid_uri and use_album_mbid_uri

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,13 @@ The following configuration values are available:
   give confusing results if not all artists in the library have proper
   sortnames.
 
+- ``local/use_artist_mbid_uri``: Whether to use the MusicBrainz ID tag
+  to generate artist URIs. Enabled by default but can cause some albums
+  with multiple artists to be incorrectly sorted.
+
+- ``local/use_album_mbid_uri``: Whether to use the MusicBrainz ID tag
+    to generate album URIs. Enabled by default and shouldn't cause issues.
+
 - ``local/album_art_files``: List of file names to check for when searching
   for external album art. These may contain UNIX shell patterns,
   i.e. ``*``, ``?``, etc.

--- a/mopidy_local/__init__.py
+++ b/mopidy_local/__init__.py
@@ -30,6 +30,8 @@ class Extension(ext.Extension):
         schema["directories"] = config.List()
         schema["timeout"] = config.Integer(optional=True, minimum=1)
         schema["use_artist_sortname"] = config.Boolean()
+        schema["use_album_mbid_uri"] = config.Boolean()
+        schema["use_artist_mbid_uri"] = config.Boolean()
         schema["album_art_files"] = config.List(optional=True)
         return schema
 

--- a/mopidy_local/ext.conf
+++ b/mopidy_local/ext.conf
@@ -37,6 +37,12 @@ timeout = 10
 # if not all artists in the library have proper sortnames
 use_artist_sortname = false
 
+# Set these to false to not use MusicBrainz IDs to create URIs
+# for artists and albums respectively. This is enabled by default
+# but can cause multi-artist albums to be sorted under the wrong artist
+use_artist_mbid_uri = true
+use_album_mbid_uri = true
+
 # a list of file names to check for when searching for external album
 # art; may contain UNIX shell patterns, i.e. "*", "?", etc.
 album_art_files = *.jpg, *.jpeg, *.png

--- a/mopidy_local/storage.py
+++ b/mopidy_local/storage.py
@@ -228,8 +228,8 @@ class LocalStorageProvider:
 
     def _model_uri(self, type, model):
         # only use valid mbids; TODO: use regex for that?
-        if model.musicbrainz_id and len(model.musicbrainz_id) == 36
-           and self._config["use_%s_mbid_uri" % type]:
+        if (model.musicbrainz_id and len(model.musicbrainz_id) == 36 and
+           self._config["use_%s_mbid_uri" % type]):
             return f"local:{type}:mbid:{model.musicbrainz_id}"
         elif type == "album":
             # ignore num_tracks for multi-disc albums

--- a/mopidy_local/storage.py
+++ b/mopidy_local/storage.py
@@ -228,7 +228,8 @@ class LocalStorageProvider:
 
     def _model_uri(self, type, model):
         # only use valid mbids; TODO: use regex for that?
-        if model.musicbrainz_id and len(model.musicbrainz_id) == 36 and self._config["use_%s_mbid_uri" % type]:
+        if model.musicbrainz_id and len(model.musicbrainz_id) == 36
+           and self._config["use_%s_mbid_uri" % type]:
             return f"local:{type}:mbid:{model.musicbrainz_id}"
         elif type == "album":
             # ignore num_tracks for multi-disc albums

--- a/mopidy_local/storage.py
+++ b/mopidy_local/storage.py
@@ -228,8 +228,11 @@ class LocalStorageProvider:
 
     def _model_uri(self, type, model):
         # only use valid mbids; TODO: use regex for that?
-        if (model.musicbrainz_id and len(model.musicbrainz_id) == 36
-           and self._config["use_%s_mbid_uri" % type]):
+        if (
+            model.musicbrainz_id
+            and len(model.musicbrainz_id) == 36
+            and self._config["use_%s_mbid_uri" % type]
+        ):
             return f"local:{type}:mbid:{model.musicbrainz_id}"
         elif type == "album":
             # ignore num_tracks for multi-disc albums

--- a/mopidy_local/storage.py
+++ b/mopidy_local/storage.py
@@ -228,8 +228,8 @@ class LocalStorageProvider:
 
     def _model_uri(self, type, model):
         # only use valid mbids; TODO: use regex for that?
-        if (model.musicbrainz_id and len(model.musicbrainz_id) == 36 and
-           self._config["use_%s_mbid_uri" % type]):
+        if (model.musicbrainz_id and len(model.musicbrainz_id) == 36
+           and self._config["use_%s_mbid_uri" % type]):
             return f"local:{type}:mbid:{model.musicbrainz_id}"
         elif type == "album":
             # ignore num_tracks for multi-disc albums

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -17,6 +17,8 @@ class LocalLibraryProviderTest(unittest.TestCase):
             "directories": [],
             "timeout": 10,
             "use_artist_sortname": False,
+            "use_artist_mbid_uri": True,
+            "use_album_mbid_uri": True,
             "album_art_files": [],
         },
     }

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -21,6 +21,8 @@ class LocalPlaybackProviderTest(unittest.TestCase):
             "directories": [],
             "timeout": 10,
             "use_artist_sortname": False,
+            "use_artist_mbid_uri": True,
+            "use_album_mbid_uri": True,
             "album_art_files": [],
         },
     }

--- a/tests/test_tracklist.py
+++ b/tests/test_tracklist.py
@@ -18,6 +18,8 @@ class LocalTracklistProviderTest(unittest.TestCase):
             "directories": [],
             "timeout": 10,
             "use_artist_sortname": False,
+            "use_artist_mbid_uri": True,
+            "use_album_mbid_uri": True,
             "album_art_files": [],
         },
     }


### PR DESCRIPTION
At least on my collection of files, about 10% of them don't sort correctly when using MBIDs to create URIs. I tag all my files using Picard, so I can't be the only person who'll encounter this.

Fixes #26 
