### PR TITLE
Remove code for creating URIs from Musicbrainz IDs

### DIFF
--- a/mopidy_local/library.py
+++ b/mopidy_local/library.py
@@ -203,9 +203,3 @@ class LocalLibraryProvider(backend.LibraryProvider):
             return [{"album": uri}]
         else:
             return []
-
-    def _model_uri(self, type, model):
-        if model.musicbrainz_id and self._config["use_%s_mbid_uri" % type]:
-            return f"local:{type}:mbid:{model.musicbrainz_id}"
-        digest = hashlib.md5(str(model)).hexdigest()
-        return f"local:{type}:md5:{digest}"

--- a/mopidy_local/library.py
+++ b/mopidy_local/library.py
@@ -1,4 +1,3 @@
-import hashlib
 import logging
 import operator
 import sqlite3

--- a/mopidy_local/storage.py
+++ b/mopidy_local/storage.py
@@ -1,3 +1,4 @@
+import hashlib
 import imghdr
 import logging
 import pathlib

--- a/mopidy_local/storage.py
+++ b/mopidy_local/storage.py
@@ -31,10 +31,7 @@ def get_image_size_gif(data):
 
 
 def model_uri(type, model):
-    # only use valid mbids; TODO: use regex for that?
-    if model.musicbrainz_id and len(model.musicbrainz_id) == 36:
-        return f"local:{type}:mbid:{model.musicbrainz_id}"
-    elif type == "album":
+    if type == "album":
         # ignore num_tracks for multi-disc albums
         digest = hashlib.md5(str(model.replace(num_tracks=None)).encode())
     else:

--- a/mopidy_local/storage.py
+++ b/mopidy_local/storage.py
@@ -1,4 +1,3 @@
-import hashlib
 import imghdr
 import logging
 import pathlib


### PR DESCRIPTION
Remove any code that was used for creating URIs from MBIDs.

Fixes #26 