### PR TITLE
Handle scan results without duration information more gracefully

### DIFF
--- a/mopidy_local/commands.py
+++ b/mopidy_local/commands.py
@@ -221,6 +221,11 @@ class ScanCommand(commands.Command):
                     logger.warning(
                         f"Failed scanning {file_uri}: No audio found in file"
                     )
+                elif result.duration is None:
+                    logger.warning(
+                        f"Failed scanning {file_uri}: "
+                        "No duration information found in file"
+                    )
                 elif result.duration < MIN_DURATION_MS:
                     logger.warning(
                         f"Failed scanning {file_uri}: "


### PR DESCRIPTION
While scanning my music library, I had `mopidy-local` crash on some files. The reason was that the respective scan results came without `duration` information. That's unfortunate, but at least happens rarely it seems.

It is currently assumed that a _playable_ scan result has _always_ duration information. As said above, that's not always the case. I believe it would be valuable to handle this this corner case more gracefully, it would make `mopidy-local` more robust. Therefore, this patch makes the meta-data scan now ignore scan results without duration information. I tested this on my local music library and was now able to scan it without further problems.

Alternatively to suggested change, `Scanner.scan()` could raise a `ScannerError` if the `duration` field is `None`. The `Scanner` implementation suggests to me though that it is explicitly wanted that `duration` can be `None` to represent an error case.

Also, the `except` statement could additionally catch all other error types and continue with the next field, to not cancel the whole scan in case of errors with individual files.  I know to little about the overall design if this is a reasonable suggestion though.