### PR TITLE
Handle both 'track' and 'track_name' distinct fields. (Fixes #44)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ v3.2.0 (UNRELEASED)
 
 - Support searching by MusicBrainz ID and disc number fields. (#42, PR: #43)
 
+- Handle both 'track' and 'track_name' distinct fields. (#44, PR: #45)
+
 
 v3.1.1 (2020-01-31)
 ===================

--- a/mopidy_local/library.py
+++ b/mopidy_local/library.py
@@ -102,7 +102,9 @@ class LocalLibraryProvider(backend.LibraryProvider):
         q = []
         for key, values in query.items() if query else []:
             q.extend((key, value) for value in values)
-        return set(schema.list_distinct(self._connect(), field, q))
+        # Gracefully handle both old and new field values for this API.
+        compat_field = {"track": "track_name"}.get(field, field)
+        return set(schema.list_distinct(self._connect(), compat_field, q))
 
     def _connect(self):
         if not self._connection:

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,6 +1,7 @@
 import pathlib
 import os
 import unittest
+from unittest import mock
 
 import pykka
 from mopidy import core
@@ -77,3 +78,10 @@ class LocalLibraryProviderTest(unittest.TestCase):
         assert empty == lib.search(uris=["local:directory"]).get()
         assert empty == lib.search(uris=["local:directory:"]).get()
         assert empty == lib.search(uris=["foobar:"]).get()
+
+    @mock.patch("mopidy_local.schema.list_distinct")
+    def test_distinct_field_track_uses_track_name(self, distinct_mock):
+        distinct_mock.return_value = []
+
+        assert self.library.get_distinct("track").get() == set()
+        distinct_mock.assert_called_once_with(mock.ANY, "track_name", [])


### PR DESCRIPTION
'track' is translated to 'track_name' so we remain compatible across Mopidy versions.