### PR TITLE
added max_search_results

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,8 @@ The following configuration values are available:
 
 - ``local/media_dir``: Path to directory with local media files.
 
+- ``local/max_search_results``: Number of search results that should be returned. Default is 100.
+
 - ``local/scan_timeout``: Number of milliseconds before giving up scanning a
   file and moving on to the next file.
 

--- a/mopidy_local/__init__.py
+++ b/mopidy_local/__init__.py
@@ -19,6 +19,7 @@ class Extension(ext.Extension):
     def get_config_schema(self):
         schema = super().get_config_schema()
         schema["library"] = config.Deprecated()
+        schema["max_search_results"] = config.Integer(minimum=0)
         schema["media_dir"] = config.Path()
         schema["data_dir"] = config.Deprecated()
         schema["playlists_dir"] = config.Deprecated()

--- a/mopidy_local/ext.conf
+++ b/mopidy_local/ext.conf
@@ -1,6 +1,7 @@
 [local]
 enabled = true
 library = sqlite
+max_search_results = 100
 media_dir = $XDG_MUSIC_DIR
 scan_timeout = 1000
 scan_flush_threshold = 100

--- a/mopidy_local/library.py
+++ b/mopidy_local/library.py
@@ -79,6 +79,7 @@ class LocalLibraryProvider(backend.LibraryProvider):
             return []
 
     def search(self, query=None, limit=100, offset=0, uris=None, exact=False):
+        limit = self._config["max_search_results"]
         q = []
         for field, values in query.items() if query else []:
             q.extend((field, value) for value in values)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -18,6 +18,7 @@ class LocalLibraryProviderTest(unittest.TestCase):
             "media_dir": path_to_data_dir(""),
             "directories": [],
             "timeout": 10,
+            "max_search_results": 100,
             "use_artist_sortname": False,
             "album_art_files": [],
         },


### PR DESCRIPTION
This adds max_seach_results as a parameter for the configuration of the local-plugin

Defaults to 100. 

Useful because there is no other way right now to get around the hard-coded limit of 100 results.