### PR TITLE
More liberal jpeg detection (Fixes #58)

### DIFF
--- a/mopidy_local/storage.py
+++ b/mopidy_local/storage.py
@@ -58,8 +58,9 @@ def get_image_size_jpeg(data):
     return width, height
 
 
-def test_jpeg(h, f):
-    if h[:2] == b"\xff\xd8":
+def test_jpeg(data, file_handle):
+    # Additional JPEG detection looking for JPEG SOI marker
+    if data[:2] == b"\xff\xd8":
         return "jpeg"
 
 

--- a/mopidy_local/storage.py
+++ b/mopidy_local/storage.py
@@ -58,6 +58,14 @@ def get_image_size_jpeg(data):
     return width, height
 
 
+def test_jpeg(h, f):
+    if h[:2] == b"\xff\xd8":
+        return "jpeg"
+
+
+imghdr.tests.append(test_jpeg)
+
+
 class LocalStorageProvider:
     def __init__(self, config):
         self._config = ext_config = config[Extension.ext_name]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,16 @@
+import pytest
+
+from mopidy_local import storage
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param("ffd8ffe000104a46494600", id="JFIF"),
+        pytest.param("ffd8ffe100184578696600", id="Exif"),
+        pytest.param("ffd8ffe1095068747470", id="XMP"),
+    ],
+)
+def test_jpeg_detection(data):
+    data_bytes = bytes.fromhex(data)
+    assert storage.imghdr.what(None, data_bytes) is not None


### PR DESCRIPTION
imghdr does not detect all jpeg files, let's accept any data
starting with the JPEG SOI marker.