### PR TITLE
Update web interface for mopidy-local

### DIFF
--- a/mopidy_local/www/index.html
+++ b/mopidy_local/www/index.html
@@ -38,7 +38,7 @@
           <img src="{{image}}" alt="Album art thumbnail; link to full size album art" loading="lazy">
         </a>
         {% end %}
-      </span>
+      </div>
     </div>
   </body>
 </html>

--- a/mopidy_local/www/index.html
+++ b/mopidy_local/www/index.html
@@ -1,43 +1,54 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Mopidy-Local</title>
+    <script type="text/javascript">
+      var file = "http://" + window.location.host + "/mopidy/mopidy.css",
+        link = document.createElement("link");
+      link.href = file;
+      link.type = "text/css";
+      link.rel = "stylesheet";
+      link.media = "screen,print";
+      document.getElementsByTagName("head")[0].appendChild(link);
+    </script>
     <style>
-      html {
-          background: #f8f8f8;
-          color: #555;
-          font-family: Geneva, Tahoma, Verdana, sans-serif;
-          line-height: 1.4em;
-      }
-      body {
-          margin: 0 auto;
-          max-width: 600px;
-      }
-      h1 {
-          font-weight: 500;
-          line-height: 1.1em;
-      }
-      a {
-          color: #555;
-          text-decoration: none;
-      }
       img {
-          border: 0;
-          height: 80px;
-          width: 80px;
+        width: 63px; height: 63px;
+        padding-left: 2px;
+        padding-right: 2px;
       }
     </style>
   </head>
   <body>
-    <h1>Mopidy-Local</h1>
-    <p>
-      This Web client is used to serve album art extracted from local
-      media files by the Mopidy-Local extension.
-    </p>
-    <div>
-      {% for image in images %}
-        <a href="{{image}}"><img src="{{image}}"></a>
-      {% end %}
+    <div class="box focus">
+      <h1>Mopidy-Local</h1>
+      <p>
+        This Web client is used to serve album art extracted from local
+        media files by the Mopidy-Local extension.
+      </p>
+    </div>
+    <div class="box">
+      <p>
+      <h2 id="b1">Mopidy-Local image cache</h2>
+      </p>
+      <span style="font-size: 0; line-height:0">
+        {% for image in images %}
+        <a style="border: 0px none;" href="{{image}}">
+          <img src="{{image}}" loading="lazy">
+        </a>
+        {% end %}
+      </span>
     </div>
   </body>
 </html>
+<script>
+  var imgwidth = (document.getElementById('b1').clientWidth / 8) - 4,
+    css = 'img {height: ' + imgwidth + 'px; width: ' + imgwidth + 'px;}',
+    head = document.head || document.getElementsByTagName('head')[0],
+    style = document.createElement('style');
+  head.appendChild(style);
+  style.type = 'text/css';
+  style.appendChild(document.createTextNode(css));
+</script>

--- a/mopidy_local/www/index.html
+++ b/mopidy_local/www/index.html
@@ -34,7 +34,7 @@
       <span id="thumbnail_container">
         {% for image in images %}
         <a href="{{image}}">
-          <img src="{{image}}" alt="Album art thumbnail; link to full size album art" loading="lazy">
+          <img id="thumbnail" src="{{image}}" alt="Album art thumbnail; link to full size album art" loading="lazy">
         </a>
         {% end %}
       </span>

--- a/mopidy_local/www/index.html
+++ b/mopidy_local/www/index.html
@@ -34,7 +34,7 @@
       <span id="thumbnail_container">
         {% for image in images %}
         <a style="border: 0px none;" href="{{image}}">
-          <img class="thumbnail" src="{{image}}" loading="lazy">
+          <img class="thumbnail" src="{{image}}" alt="Album art thumbnail; link to full size album art" loading="lazy">
         </a>
         {% end %}
       </span>

--- a/mopidy_local/www/index.html
+++ b/mopidy_local/www/index.html
@@ -9,15 +9,15 @@
       #thumbnail_container {
        display: grid;
        grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
-       grid-gap: 0px;
+       grid-gap: 2px;
        line-height: 0%;
       }
-      .thumbnail {
-          border: 0px none;
-          max-width: 98%;
-          max-height: 96%;
-          height: auto;
-          width: auto;
+      #thumbnail_container a {
+       border: none;
+      }
+      #thumbnail_container img {
+       border: none;
+       width: 100%;
       }
     </style>
   </head>
@@ -30,15 +30,14 @@
       </p>
     </div>
     <div class="box">
-      <h2 id="b1">Mopidy-Local image cache</h2>
+      <h2>Mopidy-Local image cache</h2>
       <span id="thumbnail_container">
         {% for image in images %}
-        <a style="border: 0px none;" href="{{image}}">
-          <img class="thumbnail" src="{{image}}" alt="Album art thumbnail; link to full size album art" loading="lazy">
+        <a href="{{image}}">
+          <img src="{{image}}" alt="Album art thumbnail; link to full size album art" loading="lazy">
         </a>
         {% end %}
       </span>
     </div>
   </body>
 </html>
-

--- a/mopidy_local/www/index.html
+++ b/mopidy_local/www/index.html
@@ -18,6 +18,7 @@
       #thumbnail_container img {
        border: none;
        width: 100%;
+       aspect-ratio: 1;
       }
     </style>
   </head>
@@ -31,22 +32,13 @@
     </div>
     <div class="box">
       <h2>Mopidy-Local image cache</h2>
-      <span id="thumbnail_container">
+      <div id="thumbnail_container">
         {% for image in images %}
         <a href="{{image}}">
-          <img id="thumbnail" src="{{image}}" alt="Album art thumbnail; link to full size album art" loading="lazy">
+          <img src="{{image}}" alt="Album art thumbnail; link to full size album art" loading="lazy">
         </a>
         {% end %}
       </span>
     </div>
   </body>
 </html>
-<script>
-  var imgwidth = document.getElementById('thumbnail').width;
-  var css = '#thumbnail_container img {height: ' + imgwidth + 'px;}';
-  var head = document.head || document.getElementsByTagName('head')[0];
-  var style = document.createElement('style');
-  head.appendChild(style);
-  style.type = 'text/css';
-  style.appendChild(document.createTextNode(css));
-</script>

--- a/mopidy_local/www/index.html
+++ b/mopidy_local/www/index.html
@@ -6,19 +6,19 @@
     <title>Mopidy-Local</title>
     <link rel="stylesheet" href="/mopidy/mopidy.css" type="text/css" media="screen, print">
     <style>
-      #thumbnail_container {
-       display: grid;
-       grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
-       grid-gap: 2px;
-       line-height: 0%;
+      #thumbnails {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+        grid-gap: 2px;
+        line-height: 0%;
       }
-      #thumbnail_container a {
-       border: none;
+      #thumbnails a {
+        border: none;
       }
-      #thumbnail_container img {
-       border: none;
-       width: 100%;
-       aspect-ratio: 1;
+      #thumbnails img {
+        border: none;
+        width: 100%;
+        aspect-ratio: 1;
       }
     </style>
   </head>
@@ -31,12 +31,14 @@
       </p>
     </div>
     <div class="box">
-      <h2>Mopidy-Local image cache</h2>
-      <div id="thumbnail_container">
+      <h2>Image cache</h2>
+      <p>Images extracted from local media files will automatically appear
+      here.</p>
+      <div id="thumbnails">
         {% for image in images %}
-        <a href="{{image}}">
-          <img src="{{image}}" alt="Album art thumbnail; link to full size album art" loading="lazy">
-        </a>
+          <a href="{{image}}">
+            <img src="{{image}}" alt="Album art thumbnail" loading="lazy">
+          </a>
         {% end %}
       </div>
     </div>

--- a/mopidy_local/www/index.html
+++ b/mopidy_local/www/index.html
@@ -4,20 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Mopidy-Local</title>
-    <script type="text/javascript">
-      var file = "http://" + window.location.host + "/mopidy/mopidy.css",
-        link = document.createElement("link");
-      link.href = file;
-      link.type = "text/css";
-      link.rel = "stylesheet";
-      link.media = "screen,print";
-      document.getElementsByTagName("head")[0].appendChild(link);
-    </script>
+    <link rel="stylesheet" href="/mopidy/mopidy.css" type="text/css" media="screen, print">
     <style>
-      img {
-        width: 63px; height: 63px;
-        padding-left: 2px;
-        padding-right: 2px;
+      #thumbnail_container {
+       display: grid;
+       grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+       grid-gap: 0px;
+       line-height: 0%;
+      }
+      .thumbnail {
+          border: 0px none;
+          max-width: 98%;
+          max-height: 96%;
+          height: auto;
+          width: auto;
       }
     </style>
   </head>
@@ -30,25 +30,15 @@
       </p>
     </div>
     <div class="box">
-      <p>
       <h2 id="b1">Mopidy-Local image cache</h2>
-      </p>
-      <span style="font-size: 0; line-height:0">
+      <span id="thumbnail_container">
         {% for image in images %}
         <a style="border: 0px none;" href="{{image}}">
-          <img src="{{image}}" loading="lazy">
+          <img class="thumbnail" src="{{image}}" loading="lazy">
         </a>
         {% end %}
       </span>
     </div>
   </body>
 </html>
-<script>
-  var imgwidth = (document.getElementById('b1').clientWidth / 8) - 4,
-    css = 'img {height: ' + imgwidth + 'px; width: ' + imgwidth + 'px;}',
-    head = document.head || document.getElementsByTagName('head')[0],
-    style = document.createElement('style');
-  head.appendChild(style);
-  style.type = 'text/css';
-  style.appendChild(document.createTextNode(css));
-</script>
+

--- a/mopidy_local/www/index.html
+++ b/mopidy_local/www/index.html
@@ -41,3 +41,12 @@
     </div>
   </body>
 </html>
+<script>
+  var imgwidth = document.getElementById('thumbnail').width;
+  var css = '#thumbnail_container img {height: ' + imgwidth + 'px;}';
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = document.createElement('style');
+  head.appendChild(style);
+  style.type = 'text/css';
+  style.appendChild(document.createTextNode(css));
+</script>


### PR DESCRIPTION
Have you considered using the `mopidy.css` stylesheet to style the `mopidy-local` web client?

When I added a image caching webclient to the `mopidy-youtube` front end, I formatted it using the `mopidy.css` stylesheet, so that it would be stylistically similar to the default mopidy web interface.  I also included some javascript to make sure the images scale for screens (or browser windows) that are smaller than 600px wide.  

I've made a similar suggestion for [`mopidy-bandcamp`](https://github.com/impliedchaos/mopidy-bandcamp/pull/16)

Perhaps you'd be interested in doing the same thing with `mopidy-local`.  If you are interested, the `img` style for the image thumbnails could also be moved into `mopidy.css` so the default thumbnail can be the same for all web frontends?

Cheers,
Nik


