### PR TITLE
Add setting "min_art_size" to prevent generating very small covers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,9 @@ The following configuration values are available:
   for external album art. These may contain UNIX shell patterns,
   i.e. ``*``, ``?``, etc.
 
+- ``local/min_art_size``: The minimum required size, in pixels, for an image
+  to be picked up as an album cover.
+
 
 Usage
 =====
@@ -179,6 +182,13 @@ Project resources
 - `Source code <https://github.com/mopidy/mopidy-local>`_
 - `Issue tracker <https://github.com/mopidy/mopidy-local/issues>`_
 - `Changelog <https://github.com/mopidy/mopidy-local/releases>`_
+
+
+Build locally and run
+=====================
+
+    python3 setup.py install --user
+    mopidy local scan
 
 
 Credits

--- a/mopidy_local/__init__.py
+++ b/mopidy_local/__init__.py
@@ -33,6 +33,7 @@ class Extension(ext.Extension):
         schema["timeout"] = config.Integer(optional=True, minimum=1)
         schema["use_artist_sortname"] = config.Boolean()
         schema["album_art_files"] = config.List(optional=True)
+        schema["min_art_size"] = config.Integer(minimum=0)
         return schema
 
     def setup(self, registry):

--- a/mopidy_local/ext.conf
+++ b/mopidy_local/ext.conf
@@ -44,3 +44,6 @@ use_artist_sortname = false
 # a list of file names to check for when searching for external album
 # art; may contain UNIX shell patterns, i.e. "*", "?", etc.
 album_art_files = *.jpg, *.jpeg, *.png
+
+# minimum required size, in pixels, for an image to be picked up as an album cover
+min_art_size = 32


### PR DESCRIPTION
For instance I see sometimes empty covers that are actually just a white
pixel. They shouldn't be considered as album covers.