### PR TITLE
support tracks  without a valid duration, e.g. musepack

### DIFF
--- a/mopidy_local/commands.py
+++ b/mopidy_local/commands.py
@@ -221,17 +221,15 @@ class ScanCommand(commands.Command):
                     logger.warning(
                         f"Failed scanning {file_uri}: No audio found in file"
                     )
-                elif result.duration is None:
-                    logger.warning(
-                        f"Failed scanning {file_uri}: "
-                        "No duration information found in file"
-                    )
-                elif result.duration < MIN_DURATION_MS:
+                elif result.duration and result.duration < MIN_DURATION_MS:
                     logger.warning(
                         f"Failed scanning {file_uri}: "
                         f"Track shorter than {MIN_DURATION_MS}ms"
                     )
                 else:
+                    if result.duration is None:
+                        logger.warning(f"Failed scanning {file_uri}: proceeding without duration information")
+
                     local_uri = translator.path_to_local_track_uri(
                         absolute_path, media_dir
                     )


### PR DESCRIPTION
For .mpc files the Scanner..scan() from mopidy.audio doesn't return a valid duration
which prevents these files from getting into the library.
However, those files can be played by gstreamer without any problems.
My change handles this "violation" less strictly and accepts files without a duration to be put into the library.
