### PR TITLE
Index files with invalid tags without their tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "mopidy >= 4.0.0",
+    "mopidy >= 4.0.2",
     "pykka >= 4.1",
     "uritools >= 4.0.3",
 ]

--- a/src/mopidy_local/commands.py
+++ b/src/mopidy_local/commands.py
@@ -7,6 +7,8 @@ import cyclopts
 from mopidy.audio.scan import Scanner
 from mopidy.audio.tags import convert_tags_to_track
 from mopidy.config import Config
+from mopidy.exceptions import ScannerError
+from mopidy.models import Track
 
 from mopidy_local import mtimes, storage, translator
 
@@ -249,12 +251,23 @@ def _scan_metadata(  # noqa: PLR0913
                     media_dir,
                 )
                 mtime = file_mtimes.get(absolute_path)
-                track = convert_tags_to_track(
-                    result.tags,
-                    uri=local_uri,
-                    length=result.duration,
-                    last_modified=mtime,
-                )
+                try:
+                    track = convert_tags_to_track(
+                        result.tags,
+                        uri=local_uri,
+                        length=result.duration,
+                        last_modified=mtime,
+                    )
+                except ScannerError as error:
+                    # Index the file without its tags rather than hiding it
+                    # from the library entirely.
+                    logger.warning(f"Ignoring invalid tags on {file_uri}: {error}")
+                    track = Track(
+                        uri=local_uri,
+                        name=absolute_path.name,
+                        length=result.duration,
+                        last_modified=mtime,
+                    )
                 library.add(track, result.tags, result.duration)
                 logger.debug(f"Added {track.uri}")
         except Exception as error:

--- a/src/mopidy_local/schema.py
+++ b/src/mopidy_local/schema.py
@@ -199,7 +199,7 @@ def load(c):
 
 
 def tracks(c):
-    return list(map(_track, c.execute("SELECT * FROM tracks")))
+    return _tracks(c.execute("SELECT * FROM tracks"))
 
 
 def list_distinct(c, field, query=()):
@@ -246,7 +246,7 @@ def dates(c, format="%Y-%m-%d"):  # noqa: A002
 
 
 def lookup(c, type, uri):  # noqa: A002
-    return list(map(_track, c.execute(_LOOKUP_QUERIES[type], [uri])))
+    return _tracks(c.execute(_LOOKUP_QUERIES[type], [uri]))
 
 
 def exists(c, uri):
@@ -285,7 +285,7 @@ def search_tracks(c, query, limit, offset, exact, filters=()):  # noqa: PLR0913,
     params += [limit, offset]
     logger.debug("SQLite search query %r: %s", params, sql)
     rows = c.execute(sql, params)
-    return list(map(_track, rows))
+    return _tracks(rows)
 
 
 def get_image_uris(c):
@@ -475,6 +475,28 @@ def _fulltext_query(query):
             raise LookupError(msg)
         params.append(value)
     return (" INTERSECT ".join(terms), params)
+
+
+def _tracks(rows):
+    """Convert rows to tracks, skipping any row we can't convert.
+
+    Databases created by older versions of Mopidy predate model validation, and
+    can contain values we no longer accept, e.g. dates in other formats than
+    `YYYY`, `YYYY-MM`, or `YYYY-MM-DD`.
+
+    Such rows are skipped rather than repaired on the fly. A skipped track is
+    not part of the library as far as `mopidy local scan` is concerned, so the
+    file is rescanned and its row replaced with valid data. Repairing the row
+    here would instead hide the bad data from the scan, leaving it in the
+    database forever.
+    """
+    tracks = []
+    for row in rows:
+        try:
+            tracks.append(_track(row))
+        except ValueError as error:
+            logger.warning("Skipping %s with invalid data: %s", row.uri, error)
+    return tracks
 
 
 def _track(row):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -305,3 +305,49 @@ class SchemaTest(unittest.TestCase):
         schema.cleanup(c)
         assert len(c.execute("SELECT * FROM album").fetchall()) == 0
         assert len(c.execute("SELECT * FROM artist").fetchall()) == 0
+
+    def test_tracks_skips_track_with_invalid_date(self):
+        # Databases created before we validated our models can hold dates in
+        # any format. See mopidy-local#92.
+        self.connection.execute(
+            "UPDATE track SET date = '31-12-2006' WHERE uri = ?",
+            [self.tracks[0].uri],
+        )
+
+        tracks = schema.tracks(self.connection)
+
+        assert len(tracks) == len(self.tracks) - 1
+        assert self.tracks[0].uri not in [track.uri for track in tracks]
+
+    def test_tracks_skips_track_with_invalid_album_date(self):
+        self.connection.execute(
+            "UPDATE album SET date = '12-1996' WHERE uri = ?",
+            [self.albums[0].uri],
+        )
+
+        tracks = schema.tracks(self.connection)
+
+        # tracks[2] is the only track on albums[0].
+        assert len(tracks) == len(self.tracks) - 1
+        assert self.tracks[2].uri not in [track.uri for track in tracks]
+
+    def test_lookup_skips_track_with_invalid_date(self):
+        self.connection.execute(
+            "UPDATE track SET date = '31-12-2006' WHERE uri = ?",
+            [self.tracks[0].uri],
+        )
+
+        with self.connection as c:
+            assert schema.lookup(c, ModelType.TRACK, self.tracks[0].uri) == []
+
+    def test_search_skips_track_with_invalid_date(self):
+        self.connection.execute(
+            "UPDATE track SET date = '31-12-2006' WHERE uri = ?",
+            [self.tracks[0].uri],
+        )
+
+        with self.connection as c:
+            result = schema.search_tracks(c, [], 10, 0, exact=False)
+
+        assert len(result) == len(self.tracks) - 1
+        assert self.tracks[0].uri not in [track.uri for track in result]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,5 @@
 import sqlite3
 import unittest
-from uuid import UUID
 
 from mopidy.models import Album, Artist, ModelType, Ref, Track
 
@@ -14,7 +13,7 @@ class SchemaTest(unittest.TestCase):
         Artist(
             uri="local:artist:0",
             name="artist #0",
-            musicbrainz_id=UUID("b5e8922b-5dee-44f2-85e1-7e78b69a7e1d"),
+            musicbrainz_id="b5e8922b-5dee-44f2-85e1-7e78b69a7e1d",
         ),
         Artist(uri="local:artist:1", name="artist #1"),
     ]
@@ -22,7 +21,7 @@ class SchemaTest(unittest.TestCase):
         Album(
             uri="local:album:0",
             name="album #0",
-            musicbrainz_id=UUID("13b290bc-465d-4cb8-85df-9c18c0614a66"),
+            musicbrainz_id="13b290bc-465d-4cb8-85df-9c18c0614a66",
         ),
         Album(uri="local:album:1", name="album #1", artists=[artists[0]]),
         Album(uri="local:album:2", name="album #2", artists=[artists[1]]),
@@ -58,7 +57,7 @@ class SchemaTest(unittest.TestCase):
             album=albums[2],
             composers=[artists[0]],
             performers=[artists[0]],
-            musicbrainz_id=UUID("e6cea07e-9d2d-4cd2-912f-94fd11c99763"),
+            musicbrainz_id="e6cea07e-9d2d-4cd2-912f-94fd11c99763",
         ),
     ]
 


### PR DESCRIPTION
This addresses #92, and builds upon the changes in mopidy/mopidy#2283.

When scanning, any tracks with invalid tags are no longer ignored, but added to the library with just their URI/filename.

Existing tracks from e.g. a mopidy-local database created with Mopidy 3 models are skipped if they do not pass validation using Mopidy 4's model validation. Upon the next library scan, their entry in the database will then be updated, as it looks like they're not already in the library.

Fixes #92